### PR TITLE
Make method [get_current_time] more accurate

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1,8 +1,11 @@
 import os
-from datetime import datetime, timedelta 
 
 from discord.ext import commands
 from dotenv import load_dotenv
+
+# For get_current_time
+from urllib import request, error
+from datetime import datetime, timedelta 
 
 load_dotenv()
 TOKEN = os.getenv('DISCORD_TOKEN')
@@ -11,7 +14,8 @@ bot = commands.Bot(command_prefix='!')
 user_dict = {}
 
 def get_current_time():
-    current_time = datetime.now() + timedelta(seconds=120)
+    str_time = request.urlopen('https://www.naver.com').headers['Date']
+    current_time = datetime.strptime(str_time,'%a, %d %b %Y %H:%M:%S %Z') - timedelta(hours=-9) 
     return current_time.strftime("%Y-%m-%d %H:%M:%S")
 
 def calculate_elpased(start_time, end_time):


### PR DESCRIPTION
지금 NAS 서버에서 2분씩 더하는 방식이 정확하지 않음을 확인
    - 로컬에서 time 찍고, NAS 서버 시간 +2분 한 시간이 일치하지 않았음
    - 위 2분 차이나는 이유가 불분명하니깐 저걸 사용하기도 꺼림직함

그래서 그냥 차라리 서버시간 GMT를 받고, Local time KST로 바꿔주는 방식이 더 정확할 것 같음.

